### PR TITLE
Ensure to enable EBS volume encryption

### DIFF
--- a/examples/volume-attachment/main.tf
+++ b/examples/volume-attachment/main.tf
@@ -86,4 +86,15 @@ resource "aws_ebs_volume" "this" {
   size              = 1
 
   tags = local.tags
+  # [Shisho]: The encryption will use a customer-managed key.
+  encrypted = true
+  kms_key_id = aws_kms_key.example.arn
 }
+
+# [Shisho]: See the following document:
+# https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key
+resource "aws_kms_key" "example" {
+  description             = "example"
+  deletion_window_in_days = 10
+}
+


### PR DESCRIPTION
This pull request improves our infrastructure by fixing a security issue found by [Shisho Cloud](https://shisho.dev).

## Description from Shisho Cloud

An EBS volume may be unencrypted depending on settings by an `aws_ebs_encryption_by_default` resource. The volume encryption will help you protect your data from unauthorized access to the underlying device.

